### PR TITLE
No longer provide a feature in test-helper.el

### DIFF
--- a/test/amd-mode-test.el
+++ b/test/amd-mode-test.el
@@ -28,7 +28,6 @@
 (require 'amd-mode)
 
 (require 'assess)
-(require 'test-helper)
 
 (defun test-amd--prepare-buffer (&optional buffer)
   "Configure BUFFER for javascript and amd-mode.

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -122,5 +122,4 @@ for change."
            (delete-directory ,temp-root t)
            (setq default-directory ,old-dd))))))
 
-(provide 'test-helper)
 ;;; test-helper.el ends here


### PR DESCRIPTION
The file isn't a library intended to be loaded with `require`.
Instead `ert-runner` loads it using `load`.  Other packages that
use `ert-runner` also come with a file named test-helper.el and
unfortunately many of those also provide `test-helper`, which
leads to conflicts.

Fixes #10.